### PR TITLE
destructuring graphqlHTTP

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const bodyParser = require('body-parser');
-const graphqlHttp = require('express-graphql');
+const { graphqlHTTP } = require('express-graphql');
 const mongoose = require('mongoose');
 
 const graphQlSchema = require('./graphql/schema/index');
@@ -12,7 +12,7 @@ app.use(bodyParser.json());
 
 app.use(
   '/graphql',
-  graphqlHttp({
+  graphqlHTTP({
     schema: graphQlSchema,
     rootValue: graphQlResolvers,
     graphiql: true


### PR DESCRIPTION
based on the documentation https://www.npmjs.com/package/express-graphql to solve the error: `TypeError: graphqlHTTP is not a function`